### PR TITLE
Add sticky tag

### DIFF
--- a/fluent-plugin-tag-normaliser.gemspec
+++ b/fluent-plugin-tag-normaliser.gemspec
@@ -3,12 +3,12 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name    = "fluent-plugin-tag-normaliser"
-  spec.version = "0.1.0"
+  spec.version = "0.1.1"
   spec.authors = ["Banzai Cloud"]
   spec.email   = ["info@banzaicloud.com"]
 
   spec.summary       = %q{Tag-normaliser is a `fluentd` plugin to help re-tag logs with Kubernetes metadata.}
-  spec.description   = %q{Tag-normaliser is a `fluentd` plugin to help re-tag logs with Kubernetes metadata.}
+  spec.description   = %q{Tag-normaliser is a `fluentd` plugin to help re-tag logs with Kubernetes metadata. It uses special placeholders to change tag.}
   spec.homepage      = "https://github.com/banzaicloud/fluent-plugin-tag-normaliser"
   spec.license       = "Apache-2.0"
 

--- a/test/plugin/test_out_tag_normaliser.rb
+++ b/test/plugin/test_out_tag_normaliser.rb
@@ -20,7 +20,8 @@ class TagNormaliserOutputTest < Test::Unit::TestCase
     }
     d = create_driver(config)
     d.run(default_tag: 'test') do
-      d.feed(event_time, record)
+      d.feed("tag1", event_time, record.dup)
+      d.feed("tag1", event_time, record.dup)
     end
     events = d.events
     puts events


### PR DESCRIPTION
Sticky tag will cache incoming tags and only lookup new tag in the first batch of logs.